### PR TITLE
fix: PHPDoc + typo fixed (lenght -> length)

### DIFF
--- a/src/InnValidator.php
+++ b/src/InnValidator.php
@@ -4,51 +4,75 @@ namespace devsergeev\validators;
 
 use InvalidArgumentException;
 
+/**
+ * Валидатор ИНН (Индивидуального номера налогонлательщика), российский аналог VAT
+ */
 class InnValidator
 {
-    public const CODE_INVALID_LENGHT   = 1;
+    public const CODE_INVALID_LENGTH   = 1;
     public const CODE_NOT_ONLY_DIGITS  = 2;
     public const CODE_INVALID_CHECKSUM = 3;
 
-    public static $messageInvalidLenght   = 'ИНН должен иметь длину 10 (физлицо) или 12 (юрлицо) символов';
+    public static $messageInvalidLength   = 'ИНН должен иметь длину 10 (физлицо) или 12 (юрлицо) символов';
     public static $messageOnlyDigits      = 'ИНН должен состоять только из цифр';
     public static $messageInvalidChecksum = 'ИНН недействителен (неверная контрольная сумма)';
 
+    /**
+     * Проверяет ИНН на валидность по последней (для Физлиц) или двум последним (для Юрлиц) символам
+     *
+     * @param string $inn
+     *
+     * @return bool
+     * @throws InvalidArgumentException
+     */
     public static function check(string $inn): bool
     {
         $innSymbols = str_split($inn);
-        $innLenght = mb_strlen($inn);
-        if ($innLenght === 10) {
-            self::checkInnSymbols($inn, $innLenght);
+        $innLength  = mb_strlen($inn);
+        if ($innLength === 10) {
+            self::checkInnSymbols($inn, $innLength);
             self::checkChecksum($innSymbols, 9);
-        } else if ($innLenght === 12) {
-            self::checkInnSymbols($inn, $innLenght);
+        } else if ($innLength === 12) {
+            self::checkInnSymbols($inn, $innLength);
             self::checkChecksum($innSymbols, 10);
             self::checkChecksum($innSymbols, 11);
         } else {
-            throw new InvalidArgumentException((string) self::$messageInvalidLenght, self::CODE_INVALID_LENGHT);
+            throw new InvalidArgumentException(self::$messageInvalidLength, self::CODE_INVALID_LENGTH);
         }
+
         return true;
     }
 
+    /**
+     * @param array $innSymbols
+     * @param int   $checkInnIndex
+     *
+     * @return void
+     */
     private static function checkChecksum(array $innSymbols, int $checkInnIndex): void
     {
-        $checksum = 0;
-        $offset = 11 - $checkInnIndex;
+        $checksum     = 0;
+        $offset       = 11 - $checkInnIndex;
         $coefficients = [3, 7, 2, 4, 10, 3, 5, 9, 4, 6, 8];
         for ($innIndex = 0; isset($coefficients[$innIndex + $offset]); $innIndex++) {
-            $checksum += (int) $innSymbols[$innIndex] * $coefficients[$innIndex + $offset];
+            $checksum += (int)$innSymbols[$innIndex] * $coefficients[$innIndex + $offset];
         }
         if ((int)$innSymbols[$checkInnIndex] !== $checksum % 11 % 10) {
-            throw new InvalidArgumentException((string) self::$messageInvalidChecksum, self::CODE_INVALID_CHECKSUM);
+            throw new InvalidArgumentException(self::$messageInvalidChecksum, self::CODE_INVALID_CHECKSUM);
         }
     }
 
-    private static function checkInnSymbols(string $inn, int $innLenght): void
+    /**
+     * @param string $inn
+     * @param int    $innLength
+     *
+     * @return void
+     */
+    private static function checkInnSymbols(string $inn, int $innLength): void
     {
-        for ($innIndex = 0; $innIndex < $innLenght; $innIndex++) {
+        for ($innIndex = 0; $innIndex < $innLength; $innIndex++) {
             if (!is_numeric($inn[$innIndex])) {
-                throw new InvalidArgumentException((string) self::$messageOnlyDigits, self::CODE_NOT_ONLY_DIGITS);
+                throw new InvalidArgumentException(self::$messageOnlyDigits, self::CODE_NOT_ONLY_DIGITS);
             }
         }
     }

--- a/tests/InnValidatorTest.php
+++ b/tests/InnValidatorTest.php
@@ -10,6 +10,7 @@ class InnValidatorTest extends TestCase
 {
     /**
      * @dataProvider provideValidInn
+     *
      * @param string $inn
      */
     public function testCheckValid(string $inn): void
@@ -19,6 +20,7 @@ class InnValidatorTest extends TestCase
 
     /**
      * @dataProvider provideInnWithInvalidControlsum
+     *
      * @param string $inn
      */
     public function testCheckInvalidControlsum(string $inn): void
@@ -31,20 +33,22 @@ class InnValidatorTest extends TestCase
     }
 
     /**
-     * @dataProvider provideInnWithInvalidLenght
+     * @dataProvider provideInnWithInvalidLength
+     *
      * @param string $inn
      */
-    public function testCheckInvalidLenght(string $inn): void
+    public function testCheckInvalidLength(string $inn): void
     {
         $this->expectExceptionWithMessageAndCode(
-            InnValidator::$messageInvalidLenght,
-            InnValidator::CODE_INVALID_LENGHT
+            InnValidator::$messageInvalidLength,
+            InnValidator::CODE_INVALID_LENGTH
         );
         InnValidator::check($inn);
     }
 
     /**
      * @dataProvider provideInnWithNotOnlyDigits
+     *
      * @param string $inn
      */
     public function testCheckInnWithNotOnlyDigits(string $inn): void
@@ -56,26 +60,44 @@ class InnValidatorTest extends TestCase
         InnValidator::check($inn);
     }
 
+    /**
+     * @return string[][]
+     */
     public function provideValidInn(): array
     {
         return [['3329000313'], ['7708722207'], ['5256166011'], ['5258073267'], ['366221019350']];
     }
 
+    /**
+     * @return string[][]
+     */
     public function provideInnWithInvalidControlsum(): array
     {
         return [['3329000314'], ['5256166012'], ['5258073269'], ['366221019351'], ['366221019360'], ['366221019361']];
     }
 
-    public function provideInnWithInvalidLenght(): array
+    /**
+     * @return string[][]
+     */
+    public function provideInnWithInvalidLength(): array
     {
         return [[''], ['52'], ['1234567891234'], ['*-+7/?()'], ['ghfds73267d'], ['абв221019350695']];
     }
 
+    /**
+     * @return string[][]
+     */
     public function provideInnWithNotOnlyDigits(): array
     {
         return [['ghfdsaerƢµ'], ['okptertewqer'], ['ваывавыкеу'], ['(Ͱ)-+=;4№"'], ['चीनीअक्षर1']];
     }
 
+    /**
+     * @param string $message
+     * @param int    $code
+     *
+     * @return void
+     */
     private function expectExceptionWithMessageAndCode(string $message, int $code): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
- Дополнил функции аннотациями, чтобы удобнее было работать через IDEшки
- Исправил опечатку (`lenght` -> `length`)